### PR TITLE
Use evaluation-context when adapting selection in the editor

### DIFF
--- a/game.project
+++ b/game.project
@@ -18,6 +18,7 @@ dependencies#0 = https://github.com/andsve/dirtylarry/archive/master.zip
 
 [library]
 include_dirs = texturepacker
+defold_min_version = 1.12.1
 
 [graphics]
 max_draw_calls = 1024

--- a/game.project
+++ b/game.project
@@ -18,7 +18,7 @@ dependencies#0 = https://github.com/andsve/dirtylarry/archive/master.zip
 
 [library]
 include_dirs = texturepacker
-defold_min_version = 1.12.1
+defold_min_version = 1.12.2
 
 [graphics]
 max_draw_calls = 1024


### PR DESCRIPTION
Updates to the editor integration of this plugin following changes in the editor.

Counterpart to defold/defold#11721.